### PR TITLE
Fixes typo, bad data source

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -195,7 +195,7 @@ Puppet::Type.newtype(:acl) do
         s = p.tr '-', ''
         r << (s.sub!('r', '')?'r':'-')
         r << (s.sub!('w', '')?'w':'-')
-        r << (s.sub!('x', '')?'x':'-')
+        r << (s.sub!('x', '')?'x':'-')#'
         if !s.empty?
           raise ArgumentError, %(Invalid permission set "#{p}".)
         end
@@ -213,8 +213,8 @@ Puppet::Type.newtype(:acl) do
   def newchild(path)
     full_path = ::File.join(self[:path], path)
     options = @original_parameters.merge(:name => full_path).reject { |param, value| value.nil? }
-    unless File.directory?(self[:path]) then
-      option[:permission].reject! { |acl| acl.split(':', -1).length == 4 } if options.include?(:permission)
+    unless File.directory?(options[:name]) then
+      options[:permission].reject! { |acl| acl.split(':', -1).length == 4 } if options.include?(:permission)
     end
     [:recursive, :recursemode, :path].each do |param|
       options.delete(param) if options.include?(param)


### PR DESCRIPTION
`File.directory?` test was erroneously applied against `self[:path]`
when it should be `options[:name]`, and `options` was misspelled
`option`
